### PR TITLE
Recalculate layout when size of children changes

### DIFF
--- a/flutter/lib/src/layout/node_properties.dart
+++ b/flutter/lib/src/layout/node_properties.dart
@@ -371,6 +371,19 @@ class NodeProperties {
 
   bool isCalculated() {
     return !_mapper.yGNodeLayoutGetWidth(_node).isNaN &&
-        !_mapper.yGNodeLayoutGetHeight(_node).isNaN;
+        !_mapper.yGNodeLayoutGetHeight(_node).isNaN &&
+        !_mapper.yGNodeIsDirty(_node);
+  }
+
+  void removeAllChildren() {
+    _mapper.yGNodeRemoveAllChildren(node);
+  }
+
+  void dirtyAllDescendants() {
+    _mapper.yGNodeMarkDirtyAndPropagateToDescendants(_node);
+  }
+
+  bool isDirty() {
+    return _mapper.yGNodeIsDirty(_node);
   }
 }


### PR DESCRIPTION
### The problem

The layout is not rebuilding when the size of the children changes. For example, when some additional content is loaded from REST API. As a workaround we've used the `provider` library and triggered rebuilding manually: `context.read<LayoutProviderModel>().reportChange();`

### The solution

`RenderYoga` should react to the size changes and rebuild its layout. That's the purpose of this PR.

### Known problems

1. This one doesn't work with expandable widgets.
2. The rebuilding sometimes looks laggy, for example, when the validation message appears. This might be caused because all of the nodes are removed, and then reassigned.